### PR TITLE
feat(NGUI-154): component name in rendering context as literals

### DIFF
--- a/libs/next_gen_ui_agent/renderer/json/one_card_test.py
+++ b/libs/next_gen_ui_agent/renderer/json/one_card_test.py
@@ -35,5 +35,5 @@ def test_render_json_output() -> None:
     # print(resultStr)
     assert (
         resultStr
-        == """{"image":"https://image.tmdb.org/t/p/w440_and_h660_face/uXDfjJbdP4ijW5hWSBrPrlKpxab.jpg","title":"Toy Story Details","fields":[{"name":"Title","data_path":"movie.title","data":["Toy Story"]}],"data_length":1,"field_names":["Title"]}"""
+        == """{"component":"one-card","image":"https://image.tmdb.org/t/p/w440_and_h660_face/uXDfjJbdP4ijW5hWSBrPrlKpxab.jpg","title":"Toy Story Details","fields":[{"name":"Title","data_path":"movie.title","data":["Toy Story"]}],"data_length":1,"field_names":["Title"]}"""
     )

--- a/libs/next_gen_ui_agent/renderer/types.py
+++ b/libs/next_gen_ui_agent/renderer/types.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 
 from next_gen_ui_agent.types import DataField
 from pydantic import BaseModel, Field
@@ -34,6 +34,7 @@ class RenderContextBase(RenderContextBaseTitle):
 class RenderContextAudio(RenderContextBaseTitle):
     """Rendering Context for Audio."""
 
+    component: Literal["audio"] = "audio"
     image: str
     audio: str
 
@@ -65,6 +66,7 @@ or the field name ends by either 'url' or 'link' (case insensitive)
 class RenderContextImage(RenderContextBaseTitle):
     """Rendering Context for Image"""
 
+    component: Literal["image"] = "image"
     image: Optional[str] = Field(
         description=image_desc,
         default=None,
@@ -74,6 +76,8 @@ class RenderContextImage(RenderContextBaseTitle):
 class RenderContextOneCard(RenderContextBase):
     """Rendering Context for OneCard."""
 
+    component: Literal["one-card"] = "one-card"
+
     image: Optional[str] = Field(description="Image URL", default=None)
     """Image URL"""
 
@@ -81,12 +85,16 @@ class RenderContextOneCard(RenderContextBase):
 class RenderContexSetOfCard(RenderContextBase):
     """Rendering Context for SetOfCard."""
 
+    component: Literal["set-of-cards"] = "set-of-cards"
+
     image_field: DataField
     subtitle_field: DataField
 
 
 class RenderContextVideo(RenderContextBaseTitle):
     """Rendering Context for Video."""
+
+    component: Literal["video-player"] = "video-player"
 
     video: str
     video_img: str

--- a/spec/component/image.schema.json
+++ b/spec/component/image.schema.json
@@ -4,6 +4,11 @@
     "title": {
       "type": "string"
     },
+    "component": {
+      "const": "image",
+      "default": "image",
+      "type": "string"
+    },
     "image": {
       "anyOf": [
         {

--- a/spec/component/one-card.schema.json
+++ b/spec/component/one-card.schema.json
@@ -62,6 +62,11 @@
       "description": "Maximal count of items in any data field",
       "type": "integer"
     },
+    "component": {
+      "const": "one-card",
+      "default": "one-card",
+      "type": "string"
+    },
     "image": {
       "anyOf": [
         {


### PR DESCRIPTION
Using Literals and following https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions