### PR TITLE
fix(NGUI-395): Fix wrapping for not HBC components

### DIFF
--- a/libs/next_gen_ui_agent/agent.py
+++ b/libs/next_gen_ui_agent/agent.py
@@ -162,15 +162,12 @@ class NextGenUIAgent:
             if hbc:
                 ret.append(hbc)
             else:
-                to_dynamic_selection.append(
-                    InputDataInternal(
-                        {
-                            "id": input_data["id"],
-                            "data": input_data["data"],
-                            "json_data": json_data,
-                        }
-                    )
-                )
+                # Copy input_data and just add a json_data
+                id: InputDataInternal = {
+                    **input_data,
+                    "json_data": json_data,
+                }
+                to_dynamic_selection.append(id)
 
         if to_dynamic_selection:
             inference = inference if inference else self.inference

--- a/libs/next_gen_ui_agent/agent_test.py
+++ b/libs/next_gen_ui_agent/agent_test.py
@@ -533,5 +533,32 @@ class TestComponentSelectionDataTransformation:
             await agent.component_selection(input=input)
 
 
+class TestComponentSelectionWrapping:
+    """Test suite for input data transformation in component selection step - wrapping."""
+
+    @pytest.mark.asyncio
+    async def test_component_selection_WRAPPING(self) -> None:
+        agent = NextGenUIAgent(config=AgentConfig(input_data_json_wrapping=True))
+
+        input_data = InputData(id="1", data='[{"title": "Toy Story"}]', type="my_type")
+
+        input = AgentInput(user_prompt="Test prompt", input_data=[input_data])
+        mocked_llm_component = UIComponentMetadata(
+            component="one-card",
+            id="1",
+            title="Toy Story",
+            fields=[DataField(name="Title", data_path="movie.title")],
+        )
+
+        result = await agent.component_selection(
+            input=input, inference=MockedInference(mocked_llm_component)
+        )
+        assert result is not None
+        r = result[0]
+        assert r.component == "one-card"
+        assert r.json_data is not None
+        assert r.json_data == {"my_type": [{"title": "Toy Story"}]}
+
+
 if __name__ == "__main__":
     test_design_system_handler_json()

--- a/libs/next_gen_ui_agent/types.py
+++ b/libs/next_gen_ui_agent/types.py
@@ -89,7 +89,7 @@ class InputData(TypedDict):
 class InputDataInternal(InputData):
     """Input Data used in internal call of component selection. Contain parsed JSON data."""
 
-    json_data: Any
+    json_data: NotRequired[Any | None]
 
 
 class AgentInput(TypedDict):


### PR DESCRIPTION
fixed missing type propagation.
```to_dynamic_selection.append(
                    InputDataInternal(
                        {
                            "id": input_data["id"],
                            "data": input_data["data"],
                            "json_data": json_data,
                        }
                    )
                )
```