### PR TITLE
fix(NGUI-580): field.id is required in JSONSchemas

### DIFF
--- a/.cursor/plans/make_datafield_id_required_c4e4baf6.plan.md
+++ b/.cursor/plans/make_datafield_id_required_c4e4baf6.plan.md
@@ -1,0 +1,256 @@
+---
+name: Make DataField ID required
+overview: Modify DataField and DataFieldBase to mark the id field as required in JSON Schema while maintaining backward compatibility with LLM-generated JSON that doesn't include id values.
+todos:
+  - id: modify-datafield
+    content: Modify DataField and DataFieldBase classes to remove default_factory and add model_validator that sets empty string (no UUID generation)
+    status: completed
+  - id: regenerate-schema
+    content: Regenerate JSON schemas to reflect the required id field
+    status: completed
+  - id: run-tests
+    content: Run tests to verify backward compatibility
+    status: completed
+  - id: verify-docs
+    content: Verify documentation examples are contextually appropriate (no changes needed - LLM examples correctly omit id)
+    status: completed
+isProject: false
+---
+
+# Make DataField.id and DataFieldBase.id Required in JSON Schema
+
+## Problem
+
+Currently, both field classes use `default_factory=lambda: uuid4().hex` for their `id` fields, making them optional in generated JSON Schemas:
+
+1. `[DataField.id](libs/next_gen_ui_agent/types.py)` (line 39-41)
+2. `[DataFieldBase.id](libs/next_gen_ui_agent/data_transform/types.py)` (line 27)
+
+However, the actual implementation flow reveals:
+
+**For DataField:**
+
+1. LLM generates JSON for `UIComponentMetadata` → doesn't include `id` for `DataField` objects
+2. JSON is parsed via `model_validate()` → auto-generates temporary UUIDs using `default_factory`
+3. **Key insight**: In `[agent.py:199](libs/next_gen_ui_agent/agent.py)`, the UUID is **overwritten** with `generate_field_id(field.data_path)`
+4. Final output always has proper deterministic `id` values (not UUIDs)
+
+**For DataFieldBase (and subclasses DataFieldSimpleValue, DataFieldArrayValue):**
+
+1. Fields are created during data transformation
+2. UUID is auto-generated via `default_factory`
+3. **Key insight**: In `[data_transformer_utils.py:214 and 261](libs/next_gen_ui_agent/data_transform/data_transformer_utils.py)`, the UUID is **overwritten** with `generate_field_id(field.data_path)`
+4. Final output always has proper deterministic `id` values (not UUIDs)
+
+So the UUID generation is **wasteful** in both cases since it's always replaced before output.
+
+## Solution: Use Empty String Default + Custom Schema Override
+
+Use an empty string as default (avoids UUID generation overhead) and customize the JSON Schema generator to mark `id` as required in output schemas. This approach:
+
+- Marks `id` as required in the JSON Schema (reflects final output)
+- Avoids wasteful UUID generation (since it gets overwritten anyway)
+- Maintains backward compatibility (LLM and tests don't need to provide `id`)
+- Minimal code changes
+- Works seamlessly with existing `model_validate(strict=False)` calls
+
+## Implementation Steps
+
+### 1. Modify DataField class
+
+In `[libs/next_gen_ui_agent/types.py](libs/next_gen_ui_agent/types.py)`, lines 36-42 (update the import on line 4 as well):
+
+**Before:**
+
+```python
+id: str = Field(
+    description="Unique field ID. Can be used in CSS selectors to target the field, eg. to set its style, or during live refresh of the shown data from the backend.",
+    default_factory=lambda: uuid4().hex,
+)
+```
+
+**After:**
+
+```python
+id: str = Field(
+    description="Unique field ID. Can be used in CSS selectors to target the field, eg. to set its style, or during live refresh of the shown data from the backend.",
+)
+
+@model_validator(mode='before')
+@classmethod
+def set_default_id(cls, data: Any) -> Any:
+    """Set empty string as default for id field when missing."""
+    if isinstance(data, dict) and 'id' not in data:
+        data['id'] = ""
+    return data
+```
+
+This approach:
+
+- **No UUID generation** (just empty string placeholder)
+- Marks `id` as **required** in JSON Schema (no default value on the field itself)
+- Validator provides empty string when `id` is missing (backward compatible)
+- The real ID is populated later by `[agent.py:199](libs/next_gen_ui_agent/agent.py)` via `generate_field_id(field.data_path)`
+
+### 2. Modify DataFieldBase class
+
+In `[libs/next_gen_ui_agent/data_transform/types.py](libs/next_gen_ui_agent/data_transform/types.py)`, line 27 (update the import on line 4 as well):
+
+**Before:**
+
+```python
+id: str = Field(description="Field ID", default_factory=lambda: uuid4().hex)
+```
+
+**After:**
+
+```python
+id: str = Field(description="Field ID")
+
+@model_validator(mode='before')
+@classmethod
+def set_default_id(cls, data: Any) -> Any:
+    """Set empty string as default for id field when missing."""
+    if isinstance(data, dict) and 'id' not in data:
+        data['id'] = ""
+    return data
+```
+
+This approach:
+
+- **No UUID generation** (just empty string placeholder)
+- Marks `id` as **required** in JSON Schema (no default value on the field itself)
+- Validator provides empty string when `id` is missing (backward compatible)
+- The real ID is populated later by `[data_transformer_utils.py:214,261](libs/next_gen_ui_agent/data_transform/data_transformer_utils.py)` via `generate_field_id(field.data_path)`
+
+### 3. Update imports in both files
+
+Add `model_validator` to imports:
+
+**In `[libs/next_gen_ui_agent/types.py](libs/next_gen_ui_agent/types.py)`:**
+
+```python
+from pydantic import BaseModel, Field, model_validator
+```
+
+**In `[libs/next_gen_ui_agent/data_transform/types.py](libs/next_gen_ui_agent/data_transform/types.py)`:**
+
+```python
+from pydantic import BaseModel, Discriminator, Field, model_validator
+```
+
+### 4. Regenerate JSON Schema
+
+Run the schema generation script to update the JSON Schema:
+
+```bash
+python -m next_gen_ui_mcp.spec_schema
+```
+
+This will regenerate schemas with `"id"` added to the `required` array for both `DataField` and `DataFieldBase` (and its subclasses).
+
+### 5. Verify Tests Pass
+
+Run existing tests to ensure backward compatibility:
+
+```bash
+pants test libs/next_gen_ui_agent:test
+```
+
+**Analysis of test patterns - no changes should be needed:**
+
+#### Pattern 1: Tests creating DataField/DataFieldBase WITHOUT `id`
+
+Examples:
+
+- `[agent_test.py:130](libs/next_gen_ui_agent/agent_test.py)`: `DataField(name="Title", data_path="movie.title")`
+- `[component_selection_llm_twostep_test.py:263](libs/next_gen_ui_agent/component_selection_llm_twostep_test.py)`: `DataField(name="Order ID", data_path="orders[*].id")`
+
+**Impact**: None. These will get empty string from validator (instead of UUID), then proper ID from `generate_field_id()` during processing.
+
+#### Pattern 2: Tests asserting on `field.id` values
+
+Examples:
+
+- `[all_fields_collector_test.py:80](libs/next_gen_ui_agent/all_fields_collector_test.py)`: `assert field.id == generate_field_id(field.data_path)`
+- `[mcp/agent_test.py:315](libs/next_gen_ui_mcp/agent_test.py)`: `assert component_metadata.fields[0].id == "title"`
+- `[table_test.py:41](libs/next_gen_ui_agent/data_transform/table_test.py)`: `assert result.fields[0].id == "movies-title"`
+- `[data_transformer_utils_test.py:531](libs/next_gen_ui_agent/data_transform/data_transformer_utils_test.py)`: `assert fields[0].id == "movies-string"`
+
+**Impact**: None. All assertions check AFTER processing, when `generate_field_id()` has already set the proper deterministic ID.
+
+#### Pattern 3: Tests creating DataField WITH explicit `id`
+
+Examples:
+
+- `[all_fields_collector_test.py:16-17](libs/next_gen_ui_agent/all_fields_collector_test.py)`: `DataField(id="field1", name="Field 1", ...)`
+- `[all_fields_collector_test.py:48](libs/next_gen_ui_agent/all_fields_collector_test.py)`: `DataField(id="items-name", name="Name", ...)`
+
+**Impact**: None. Explicit ID values are preserved and used.
+
+Key test files to monitor:
+
+- `[libs/next_gen_ui_agent/component_selection_llm_strategy_test.py](libs/next_gen_ui_agent/component_selection_llm_strategy_test.py)` (DataField - LLM parsing)
+- `[libs/next_gen_ui_agent/agent_test.py](libs/next_gen_ui_agent/agent_test.py)` (DataField - full flow)
+- `[libs/next_gen_ui_agent/all_fields_collector_test.py](libs/next_gen_ui_agent/all_fields_collector_test.py)` (DataField - ID generation)
+- `[libs/next_gen_ui_agent/data_transform/data_transformer_utils_test.py](libs/next_gen_ui_agent/data_transform/data_transformer_utils_test.py)` (DataFieldBase - array processing)
+- `[libs/next_gen_ui_agent/data_transform/table_test.py](libs/next_gen_ui_agent/data_transform/table_test.py)` (DataFieldBase - table transformer)
+- `[libs/next_gen_ui_agent/data_transform/one_card_test.py](libs/next_gen_ui_agent/data_transform/one_card_test.py)` (DataFieldBase - card transformer)
+
+## Why This Works
+
+1. **Schema Generation**: Without default on the Field, Pydantic marks `id` as required in JSON Schema
+2. **No UUID Overhead**: Uses empty string instead of generating wasteful UUIDs that get overwritten
+3. **LLM Parsing**: The validator runs during `model_validate()` and sets empty string when `id` is missing
+4. **Backward Compatible**: Existing code that doesn't provide `id` continues to work (validator fills it)
+5. **Forward Compatible**: Code that explicitly provides `id` values works unchanged
+6. **Type Safety**: The field remains `str`, not `Optional[str]`
+7. **Final ID Generation**:
+  - For `DataField`: `agent.py:199` overwrites with deterministic ID from `data_path`
+  - For `DataFieldBase`: `data_transformer_utils.py:214,261` overwrites with deterministic ID from `data_path`
+
+## Documentation Review
+
+**Analyzed documentation for JSON examples without `id` fields:**
+
+**1. `[docs/guide/llm/prompt_tuning.md](docs/guide/llm/prompt_tuning.md)` (lines 151-156, 166-170)**
+
+- Shows **LLM prompt examples** for custom examples configuration
+- **Correctly omits `id**` because these show LLM output format (LLM doesn't generate IDs)
+- **No changes needed** ✓
+
+**2. `.cursor/plans/configurable_examples_templates_c4b4eb77.plan.md**`
+
+- Old plan file with LLM output examples
+- **No changes needed** (plan file, and examples are correct anyway) ✓
+
+**3. `[libs/next_gen_ui_mcp/README.md](libs/next_gen_ui_mcp/README.md)` and `[spec/component/README.md](spec/component/README.md)**`
+
+- Show **final output format** (after processing)
+- **Already include `id` fields** ✓
+
+**Conclusion**: All documentation examples are contextually appropriate. No updates needed.
+
+## Test Expectations Summary
+
+**No test code changes needed** because:
+
+1. Tests creating fields without `id` will automatically get empty string (via validator) then proper ID (via `generate_field_id()`)
+2. All test assertions on `id` values check AFTER processing when deterministic IDs are already set
+3. Tests providing explicit `id` values will continue to work unchanged
+
+The only observable difference is:
+
+- **Before**: Fields temporarily have UUID values before being overwritten
+- **After**: Fields temporarily have empty string "" before being set to proper ID
+- **Result**: Same final state, but more efficient (no wasteful UUID generation)
+
+## Alternative Approaches Considered
+
+1. **Keep UUID Generation**: Original plan was to use `model_validator` with UUID generation, but this is wasteful since `agent.py:199` overwrites it anyway
+2. **Use `default=""**`: Simpler but makes field optional in schema (doesn't reflect final output where it's always present)
+3. **Separate Input/Output Models**: More refactoring, would require creating `DataFieldInput`/`DataFieldOutput` and converting between models
+4. **Custom Schema Generator Override**: Complex approach requiring modifications to `CustomGenerateJsonSchema` to special-case `DataField.id`
+5. **Field Validator**: Less flexible than model validator for handling missing keys
+
+The model validator with empty string approach provides the cleanest solution with minimal changes and no wasteful UUID generation.

--- a/libs/next_gen_ui_agent/agent_test.py
+++ b/libs/next_gen_ui_agent/agent_test.py
@@ -127,7 +127,7 @@ class TestSelectComponent:
             component="one-card",
             id="1",
             title="Toy Story",
-            fields=[DataField(name="Title", data_path="movie.title")],
+            fields=[DataField(id="title", name="Title", data_path="movie.title")],
         )
         agent = NextGenUIAgent(config=AgentConfig())
         input_data = InputData(id="1", data='{"title": "Toy Story"}')
@@ -514,7 +514,7 @@ class TestSelectComponent_InputDataJsonWrapping:
             component="one-card",
             id="1",
             title="Toy Story",
-            fields=[DataField(name="Title", data_path="movie.title")],
+            fields=[DataField(id="title", name="Title", data_path="movie.title")],
         )
 
         component = await agent.select_component(
@@ -540,7 +540,7 @@ class TestRefreshComponent:
                 component="one-card",
                 id="1",
                 title="Toy Story",
-                fields=[DataField(name="Title", data_path="movie.title")],
+                fields=[DataField(id="title", name="Title", data_path="movie.title")],
             ),
             json_wrapping_field_name="my_type",
         )
@@ -571,7 +571,7 @@ class TestRefreshComponent:
                 component="one-card",
                 id="1",
                 title="Toy Story",
-                fields=[DataField(name="Title", data_path="$..title")],
+                fields=[DataField(id="title", name="Title", data_path="$..title")],
             ),
             input_data_transformer_name="json",
         )
@@ -596,7 +596,9 @@ class TestRefreshComponent:
                 component="one-card",
                 id="1",
                 title="Toy Story",
-                fields=[DataField(name="Title", data_path="$..my_type.title")],
+                fields=[
+                    DataField(id="title", name="Title", data_path="$..my_type.title")
+                ],
             ),
             input_data_transformer_name="json",
             json_wrapping_field_name="my_type",
@@ -630,8 +632,8 @@ class TestConstructUIBlockConfiguration:
             id="1",
             title="Toy Story",
             fields=[
-                DataField(name="Title", data_path="$..movie.title"),
-                DataField(name="Year", data_path="['movie']['year']"),
+                DataField(id="title", name="Title", data_path="$..movie.title"),
+                DataField(id="year", name="Year", data_path="['movie']['year']"),
             ],
             input_data_transformer_name="json",
             json_wrapping_field_name="my_type",
@@ -674,7 +676,7 @@ class TestConstructUIBlockConfiguration:
             component="one-card",
             id="1",
             title="Toy Story",
-            fields=[DataField(name="Title", data_path="movie.title")],
+            fields=[DataField(id="title", name="Title", data_path="movie.title")],
             input_data_transformer_name="yaml",
             json_wrapping_field_name=None,
             json_data=[{"title": "Toy Story"}],
@@ -710,7 +712,7 @@ class TestConstructUIBlockConfiguration:
             component="table",
             id="1",
             title="Toy Story",
-            fields=[DataField(name="Title", data_path="my_type[*].title")],
+            fields=[DataField(id="title", name="Title", data_path="my_type[*].title")],
             json_data={"my_type": [{"title": "Toy Story", "year": 2024}]},
         )
         configuration = agent.construct_UIBlockConfiguration(
@@ -748,7 +750,7 @@ class TestConstructUIBlockConfiguration:
             component="table",
             id="1",
             title="Toy Story",
-            fields=[DataField(name="Title", data_path="my_type[*].title")],
+            fields=[DataField(id="title", name="Title", data_path="my_type[*].title")],
             json_data={"my_type": [{"title": "Toy Story", "year": 2024}]},
         )
         configuration = agent.construct_UIBlockConfiguration(
@@ -807,7 +809,7 @@ class TestConstructUIBlockConfiguration:
             component="table",
             id="1",
             title="Toy Story",
-            fields=[DataField(name="Title", data_path="my_type[*].title")],
+            fields=[DataField(id="title", name="Title", data_path="my_type[*].title")],
             json_data={"my_type": [{"title": "Toy Story", "year": 2024}]},
         )
         configuration = agent.construct_UIBlockConfiguration(
@@ -850,7 +852,7 @@ class TestConstructUIBlockConfiguration:
             component="table",
             id="1",
             title="Toy Story",
-            fields=[DataField(name="Title", data_path="my_type[*].title")],
+            fields=[DataField(id="title", name="Title", data_path="my_type[*].title")],
             json_data={"my_type": [{"title": "Toy Story", "year": 2024}]},
         )
         configuration = agent.construct_UIBlockConfiguration(
@@ -906,7 +908,7 @@ class TestConstructUIBlockConfiguration:
             component="one-card",
             id="1",
             title="Toy Story",
-            fields=[DataField(name="Title", data_path="title")],
+            fields=[DataField(id="title", name="Title", data_path="title")],
             input_data_transformer_name="json",
             json_wrapping_field_name=None,
             json_data={"title": "Toy Story"},
@@ -935,7 +937,7 @@ class TestConstructUIBlockConfiguration:
             component="one-card",
             id="1",
             title="Toy Story",
-            fields=[DataField(name="Title", data_path="title")],
+            fields=[DataField(id="title", name="Title", data_path="title")],
             input_data_transformer_name="json",
             json_wrapping_field_name=None,
             json_data={"title": "Toy Story"},

--- a/libs/next_gen_ui_agent/data_transform/types.py
+++ b/libs/next_gen_ui_agent/data_transform/types.py
@@ -1,7 +1,6 @@
 from typing import Annotated, Any, Literal, Optional, Union
-from uuid import uuid4
 
-from pydantic import BaseModel, Discriminator, Field
+from pydantic import BaseModel, Discriminator, Field, model_validator
 
 
 class ComponentDataBase(BaseModel):
@@ -24,10 +23,18 @@ class ComponentDataBaseWithTitle(ComponentDataBase):
 class DataFieldBase(BaseModel):
     """Base of the Component Data Field model"""
 
-    id: str = Field(description="Field ID", default_factory=lambda: uuid4().hex)
+    id: str = Field(description="Field ID")
     name: str = Field(description="Field name")
     data_path: str = Field(description="JSON Path to input data")
     data: Any
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_default_id(cls, data: Any) -> Any:
+        """Set empty string as default for id field when missing. It is generated later by code that processes the data."""
+        if isinstance(data, dict) and "id" not in data:
+            data["id"] = ""
+        return data
 
 
 DataFieldBasicDataType = Union[str | int | float | bool]

--- a/libs/next_gen_ui_agent/types.py
+++ b/libs/next_gen_ui_agent/types.py
@@ -1,8 +1,7 @@
 from abc import ABC
 from typing import Any, Literal, Optional
-from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing_extensions import NotRequired, TypedDict
 
 CONFIG_OPTIONS_DATA_TRANSFORMER = Optional[
@@ -38,7 +37,6 @@ class DataField(BaseModel):
 
     id: str = Field(
         description="Unique field ID. Can be used in CSS selectors to target the field, eg. to set its style, or during live refresh of the shown data from the backend.",
-        default_factory=lambda: uuid4().hex,
     )
     """Unique field ID. Can be used for frontend customizations, eg. using it in CSS class names to target the field and set its style. Or as a field id during live refresh of the shown data from the backend."""
 
@@ -49,6 +47,14 @@ class DataField(BaseModel):
         description="JSON Path pointing to the input data structure (after input data transformation and JSON wrapping, if applied). It is used to pickup values to be shown in the UI."
     )
     """JSON Path pointing to the input data structure (after input data transformation and JSON wrapping, if applied). It is used to pickup values to be shown in the UI."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_default_id(cls, data: Any) -> Any:
+        """Set empty string as default for id field when missing. It is generated later by code that processes the data."""
+        if isinstance(data, dict) and "id" not in data:
+            data["id"] = ""
+        return data
 
 
 class AgentConfigDynamicComponentConfiguration(BaseModel):

--- a/spec/a2a/a2a_agent_config.schema.json
+++ b/spec/a2a/a2a_agent_config.schema.json
@@ -636,6 +636,7 @@
         }
       },
       "required": [
+        "id",
         "name",
         "data_path"
       ],

--- a/spec/component/one-card.schema.json
+++ b/spec/component/one-card.schema.json
@@ -38,6 +38,7 @@
         }
       },
       "required": [
+        "id",
         "name",
         "data_path"
       ],

--- a/spec/component/set-of-cards.schema.json
+++ b/spec/component/set-of-cards.schema.json
@@ -60,6 +60,7 @@
         }
       },
       "required": [
+        "id",
         "name",
         "data_path"
       ],

--- a/spec/component/table.schema.json
+++ b/spec/component/table.schema.json
@@ -60,6 +60,7 @@
         }
       },
       "required": [
+        "id",
         "name",
         "data_path"
       ],

--- a/spec/config/agent_config.schema.json
+++ b/spec/config/agent_config.schema.json
@@ -483,6 +483,7 @@
         }
       },
       "required": [
+        "id",
         "name",
         "data_path"
       ],

--- a/spec/mcp/generate_ui_output.schema.json
+++ b/spec/mcp/generate_ui_output.schema.json
@@ -17,6 +17,7 @@
         }
       },
       "required": [
+        "id",
         "name",
         "data_path"
       ],

--- a/spec/mcp/mcp_agent_config.schema.json
+++ b/spec/mcp/mcp_agent_config.schema.json
@@ -483,6 +483,7 @@
         }
       },
       "required": [
+        "id",
         "name",
         "data_path"
       ],

--- a/spec/output/ui_block.schema.json
+++ b/spec/output/ui_block.schema.json
@@ -17,6 +17,7 @@
         }
       },
       "required": [
+        "id",
         "name",
         "data_path"
       ],


### PR DESCRIPTION
As we discussed with @jschuler during NPM work, `field.id` must be marked as required in all JSONSchemas where mentioned, as it is an important identifier for the UI (used to generate unique field classes, but also to reference fields in customizations).